### PR TITLE
Fix docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.11
+FROM node:12.10.0-alpine
 
 WORKDIR /usr/src
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,4 @@ services:
     build: .
     volumes:
       - ".:/usr/src"
+      - /usr/src/node_modules


### PR DESCRIPTION
Expected node version is >=12 in package.json, but we used 10.11 in the Dockerfile.

We were also overriding the `node_modules` directory when the volume was mounted.